### PR TITLE
Add Solana dev tooling endpoints and Coinbase Commerce integration

### DIFF
--- a/src/utils/coinbaseClient.js
+++ b/src/utils/coinbaseClient.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const axios = require('axios');
+const crypto = require('crypto');
+const logger = require('./logger');
+
+const API_BASE_URL = 'https://api.commerce.coinbase.com';
+
+class CoinbaseClient {
+  constructor(options = {}) {
+    this.apiKey = options.apiKey || process.env.COINBASE_COMMERCE_API_KEY || null;
+    this.webhookSecret = options.webhookSecret || process.env.COINBASE_COMMERCE_WEBHOOK_SECRET || null;
+    this.apiVersion = options.apiVersion || '2022-01-11';
+
+    this.http = axios.create({
+      baseURL: API_BASE_URL,
+      timeout: options.timeout || 15_000,
+      headers: {
+        'X-CC-Version': this.apiVersion,
+        'Content-Type': 'application/json'
+      }
+    });
+
+    if (this.apiKey) {
+      this.http.defaults.headers.common['X-CC-Api-Key'] = this.apiKey;
+    }
+  }
+
+  assertApiKey() {
+    if (!this.apiKey) {
+      throw new Error('Coinbase Commerce API key not configured');
+    }
+  }
+
+  async createCharge(payload) {
+    this.assertApiKey();
+
+    const body = {
+      name: payload.name,
+      description: payload.description,
+      pricing_type: payload.pricingType || 'fixed_price',
+      local_price: payload.localPrice,
+      metadata: payload.metadata || {},
+      redirect_url: payload.redirectUrl,
+      cancel_url: payload.cancelUrl,
+      pricing: payload.pricing,
+      payments: payload.payments
+    };
+
+    const summary = {
+      name: body.name,
+      amount: body.local_price ? body.local_price.amount : undefined,
+      currency: body.local_price ? body.local_price.currency : undefined
+    };
+    logger.info('[coinbase] Creating charge', summary);
+    const response = await this.http.post('/charges', body);
+    return response.data.data;
+  }
+
+  async getCharge(chargeId) {
+    this.assertApiKey();
+    const response = await this.http.get(`/charges/${chargeId}`);
+    return response.data.data;
+  }
+
+  verifyWebhookSignature(rawBody, signature, secret = this.webhookSecret) {
+    if (!secret) {
+      throw new Error('Coinbase Commerce webhook secret not configured');
+    }
+
+    if (!signature) {
+      return false;
+    }
+
+    const computed = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+    const computedBuffer = Buffer.from(computed, 'utf8');
+    const signatureBuffer = Buffer.from(signature, 'utf8');
+
+    if (computedBuffer.length !== signatureBuffer.length) {
+      return false;
+    }
+
+    return crypto.timingSafeEqual(computedBuffer, signatureBuffer);
+  }
+}
+
+module.exports = new CoinbaseClient();
+module.exports.CoinbaseClient = CoinbaseClient;

--- a/src/utils/solanaDevTools.js
+++ b/src/utils/solanaDevTools.js
@@ -1,0 +1,220 @@
+'use strict';
+
+const { Connection, PublicKey, Keypair, clusterApiUrl } = require('@solana/web3.js');
+const { Metaplex, keypairIdentity, irysStorage } = require('@metaplex-foundation/js');
+const bs58 = require('bs58').default;
+const logger = require('./logger');
+
+const DEFAULT_CLUSTER = process.env.SOLANA_CLUSTER || 'mainnet-beta';
+const SUPPORTED_CLUSTERS = new Set(['mainnet-beta', 'testnet', 'devnet', 'localnet']);
+
+const state = {
+  connections: new Map(),
+  metaplexClients: new Map(),
+  mintAuthorities: new Map(),
+  nftStorageApiKey: process.env.NFT_STORAGE_API_KEY || null,
+  lastErrors: new Map()
+};
+
+function getClusterRpcUrl(cluster, overrideUrl) {
+  if (overrideUrl) {
+    return overrideUrl;
+  }
+
+  if (!SUPPORTED_CLUSTERS.has(cluster)) {
+    throw new Error(`Unsupported Solana cluster: ${cluster}`);
+  }
+
+  if (cluster === 'localnet') {
+    return process.env.SOLANA_LOCALNET_RPC_URL || 'http://127.0.0.1:8899';
+  }
+
+  return clusterApiUrl(cluster);
+}
+
+function getConnection(cluster = DEFAULT_CLUSTER, rpcUrl) {
+  const resolvedCluster = cluster || DEFAULT_CLUSTER;
+  const url = getClusterRpcUrl(resolvedCluster, rpcUrl);
+  const cacheKey = `${resolvedCluster}:${url}`;
+
+  if (!state.connections.has(cacheKey)) {
+    const connection = new Connection(url, 'confirmed');
+    state.connections.set(cacheKey, { connection, url, cluster: resolvedCluster, lastReadyCheck: Date.now() });
+    logger.info(`[solana-dev-tools] Created connection for ${resolvedCluster} → ${url}`);
+  }
+
+  const cached = state.connections.get(cacheKey);
+  cached.lastReadyCheck = Date.now();
+  return cached.connection;
+}
+
+function loadMintAuthority(secret, cluster) {
+  if (!secret) {
+    return null;
+  }
+
+  const cacheKey = `${cluster}:${secret.substring(0, 16)}`;
+  if (state.mintAuthorities.has(cacheKey)) {
+    return state.mintAuthorities.get(cacheKey);
+  }
+
+  try {
+    const keypair = Keypair.fromSecretKey(bs58.decode(secret));
+    state.mintAuthorities.set(cacheKey, keypair);
+    return keypair;
+  } catch (error) {
+    state.lastErrors.set('mintAuthority', error);
+    throw new Error(`Failed to load mint authority: ${error.message}`);
+  }
+}
+
+function createMetaplex(connection, mintAuthority, cluster) {
+  if (!mintAuthority) {
+    return null;
+  }
+
+  const cacheKey = `${cluster}:${mintAuthority.publicKey.toBase58()}`;
+  if (state.metaplexClients.has(cacheKey)) {
+    return state.metaplexClients.get(cacheKey);
+  }
+
+  const metaplex = Metaplex.make(connection)
+    .use(keypairIdentity(mintAuthority))
+    .use(irysStorage({
+      address: process.env.IRYS_ADDRESS,
+      providerUrl: connection.rpcEndpoint,
+      timeout: 60_000
+    }));
+
+  state.metaplexClients.set(cacheKey, metaplex);
+  return metaplex;
+}
+
+function initialize(options = {}) {
+  const {
+    cluster = DEFAULT_CLUSTER,
+    rpcUrl,
+    mintAuthoritySecret = process.env.MINT_AUTHORITY_KEYPAIR,
+    nftStorageApiKey = process.env.NFT_STORAGE_API_KEY
+  } = options;
+
+  state.nftStorageApiKey = nftStorageApiKey;
+
+  const connection = getConnection(cluster, rpcUrl);
+  let metaplex = null;
+  let mintAuthority = null;
+
+  if (mintAuthoritySecret) {
+    try {
+      mintAuthority = loadMintAuthority(mintAuthoritySecret, cluster);
+      metaplex = createMetaplex(connection, mintAuthority, cluster);
+      logger.info(`[solana-dev-tools] Minting enabled for ${cluster}`);
+    } catch (error) {
+      logger.error(`[solana-dev-tools] Failed to initialize minting for ${cluster}: ${error.message}`);
+      state.lastErrors.set(cluster, error);
+    }
+  } else {
+    logger.warn(`[solana-dev-tools] Mint authority secret missing for ${cluster}. NFT minting disabled.`);
+  }
+
+  return { connection, metaplex, mintAuthority };
+}
+
+async function getProgramAccounts(programId, options = {}) {
+  const { cluster = DEFAULT_CLUSTER, rpcUrl, config } = options;
+  const connection = getConnection(cluster, rpcUrl);
+  const programPublicKey = new PublicKey(programId);
+  const accounts = await connection.getProgramAccounts(programPublicKey, config);
+
+  return accounts.map((account) => ({
+    pubkey: account.pubkey.toBase58(),
+    lamports: account.account.lamports,
+    owner: account.account.owner.toBase58(),
+    executable: account.account.executable,
+    rentEpoch: account.account.rentEpoch,
+    dataLength: account.account.data.length
+  }));
+}
+
+async function requestAirdrop(walletAddress, lamports, options = {}) {
+  const { cluster = 'devnet', rpcUrl } = options;
+  if (cluster === 'mainnet-beta') {
+    throw new Error('Airdrops are not available on mainnet-beta');
+  }
+
+  const connection = getConnection(cluster, rpcUrl);
+  const publicKey = new PublicKey(walletAddress);
+  const signature = await connection.requestAirdrop(publicKey, lamports);
+  return { signature };
+}
+
+async function getNftMetadata(mintAddress, options = {}) {
+  const { cluster = DEFAULT_CLUSTER, rpcUrl, mintAuthoritySecret } = options;
+  const connection = getConnection(cluster, rpcUrl);
+  const mintAuthority = mintAuthoritySecret ? loadMintAuthority(mintAuthoritySecret, cluster) : null;
+  const metaplex = createMetaplex(connection, mintAuthority, cluster);
+
+  if (!metaplex) {
+    throw new Error('Metaplex client not initialized. Mint authority secret required.');
+  }
+
+  const mint = new PublicKey(mintAddress);
+  const nft = await metaplex.nfts().findByMint({ mintAddress: mint });
+  return {
+    mint: nft.mint.address.toBase58(),
+    name: nft.name,
+    symbol: nft.symbol,
+    uri: nft.uri,
+    json: nft.json ?? null,
+    updateAuthority: nft.updateAuthorityAddress.toBase58(),
+    sellerFeeBasisPoints: nft.sellerFeeBasisPoints
+  };
+}
+
+function getStatus() {
+  const connections = [];
+  for (const [key, value] of state.connections.entries()) {
+    connections.push({
+      cacheKey: key,
+      cluster: value.cluster,
+      rpcUrl: value.url,
+      lastReadyCheck: value.lastReadyCheck
+    });
+  }
+
+  const metaplexClients = [];
+  for (const [key, client] of state.metaplexClients.entries()) {
+    metaplexClients.push({
+      cacheKey: key,
+      identity: client.identity().publicKey.toBase58()
+    });
+  }
+
+  const mintAuthorities = [];
+  for (const [key, keypair] of state.mintAuthorities.entries()) {
+    mintAuthorities.push({ cacheKey: key, publicKey: keypair.publicKey.toBase58() });
+  }
+
+  const lastErrors = [];
+  for (const [scope, error] of state.lastErrors.entries()) {
+    lastErrors.push({ scope, message: error.message });
+  }
+
+  return {
+    defaultCluster: DEFAULT_CLUSTER,
+    connections,
+    metaplexClients,
+    mintAuthorities,
+    nftStorageConfigured: Boolean(state.nftStorageApiKey),
+    lastErrors
+  };
+}
+
+module.exports = {
+  initialize,
+  getConnection,
+  getProgramAccounts,
+  requestAirdrop,
+  getNftMetadata,
+  getStatus
+};


### PR DESCRIPTION
## Summary
- add a shared Solana dev tools utility to manage cluster connections, program queries, airdrops, and NFT metadata helpers
- extend the API to surface Solana dev tools diagnostics plus Coinbase Commerce charge/webhook endpoints
- introduce a Coinbase Commerce client helper for creating charges and verifying webhook signatures

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690875d32824832fbf8dbc9f17c1a56f