### PR TITLE
Add trustless tipping flow with TrustBadge verification

### DIFF
--- a/db/database.js
+++ b/db/database.js
@@ -100,6 +100,24 @@ class Database {
     }
   }
 
+  async getRecentTips(limit = 20) {
+    return sqlite.getRecentTips(limit);
+  }
+
+  async updateReputation(discordId, delta) {
+    sqlite.updateReputationScore(discordId, delta);
+    return sqlite.getReputationScore(discordId);
+  }
+
+  async getTrustBadge(discordId) {
+    return sqlite.getTrustBadgeByDiscordId(discordId);
+  }
+
+  async saveTrustBadge(discordId, walletAddress, mintAddress, initialScore = 0) {
+    sqlite.upsertTrustBadge(discordId, walletAddress, mintAddress, initialScore);
+    return sqlite.getTrustBadgeByDiscordId(discordId);
+  }
+
   // Graceful shutdown
   async close() {
     // SQLite will close automatically when process exits

--- a/justthetip-contracts/programs/justthetip/src/lib.rs
+++ b/justthetip-contracts/programs/justthetip/src/lib.rs
@@ -1,6 +1,8 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::{self, Token, TokenAccount, Transfer};
 
+pub mod trust_badge;
+
 // IMPORTANT: Update this program ID after deployment
 // This is a placeholder - run `anchor keys list` after building to get your actual program ID
 // For production, use different program IDs for devnet and mainnet

--- a/justthetip-contracts/programs/justthetip/src/trust_badge.rs
+++ b/justthetip-contracts/programs/justthetip/src/trust_badge.rs
@@ -1,0 +1,164 @@
+use anchor_lang::prelude::*;
+use anchor_spl::associated_token::AssociatedToken;
+use anchor_spl::token::{self, Mint, MintTo, Token, TokenAccount};
+
+#[program]
+pub mod trust_badge {
+    use super::*;
+
+    pub fn mint_badge(ctx: Context<MintBadge>, initial_score: u64) -> Result<()> {
+        require!(initial_score <= 10_000, TrustBadgeError::ScoreOutOfRange);
+
+        let badge = &mut ctx.accounts.badge;
+        badge.owner = ctx.accounts.recipient.key();
+        badge.mint = ctx.accounts.badge_mint.key();
+        badge.reputation_score = initial_score;
+        badge.bump = *ctx.bumps.get("badge").ok_or(TrustBadgeError::MissingBump)?;
+        badge.authority = ctx.accounts.authority.key();
+
+        let cpi_accounts = MintTo {
+            mint: ctx.accounts.badge_mint.to_account_info(),
+            to: ctx.accounts.recipient_token_account.to_account_info(),
+            authority: ctx.accounts.mint_authority.to_account_info(),
+        };
+
+        let cpi_program = ctx.accounts.token_program.to_account_info();
+        let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
+        token::mint_to(cpi_ctx, 1)?;
+
+        emit!(BadgeMinted {
+            owner: badge.owner,
+            mint: badge.mint,
+            reputation_score: badge.reputation_score,
+        });
+
+        Ok(())
+    }
+
+    pub fn update_score(ctx: Context<UpdateScore>, delta: i64) -> Result<()> {
+        let badge = &mut ctx.accounts.badge;
+        require_keys_eq!(badge.authority, ctx.accounts.authority.key(), TrustBadgeError::Unauthorized);
+
+        let updated_score = if delta.is_negative() {
+            badge
+                .reputation_score
+                .checked_sub(delta.unsigned_abs())
+                .ok_or(TrustBadgeError::ScoreOutOfRange)?
+        } else {
+            badge
+                .reputation_score
+                .checked_add(delta as u64)
+                .ok_or(TrustBadgeError::ScoreOutOfRange)?
+        };
+
+        badge.reputation_score = updated_score;
+        emit!(ScoreUpdated {
+            owner: badge.owner,
+            mint: badge.mint,
+            reputation_score: badge.reputation_score,
+        });
+        Ok(())
+    }
+
+    pub fn get_score(ctx: Context<GetScore>) -> Result<()> {
+        emit!(ScoreQueried {
+            owner: ctx.accounts.badge.owner,
+            mint: ctx.accounts.badge.mint,
+            reputation_score: ctx.accounts.badge.reputation_score,
+        });
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct MintBadge<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    pub mint_authority: Signer<'info>,
+    #[account(
+        init,
+        payer = authority,
+        space = TrustBadge::LEN,
+        seeds = [b"trust-badge", recipient.key().as_ref()],
+        bump,
+    )]
+    pub badge: Account<'info, TrustBadge>;
+    #[account(mut)]
+    pub badge_mint: Account<'info, Mint>;
+    #[account(
+        init_if_needed,
+        payer = authority,
+        associated_token::mint = badge_mint,
+        associated_token::authority = recipient,
+    )]
+    pub recipient_token_account: Account<'info, TokenAccount>;
+    pub recipient: SystemAccount<'info>;
+    pub token_program: Program<'info, Token>;
+    pub associated_token_program: Program<'info, AssociatedToken>;
+    pub system_program: Program<'info, System>;
+    pub rent: Sysvar<'info, Rent>;
+}
+
+#[derive(Accounts)]
+pub struct UpdateScore<'info> {
+    pub authority: Signer<'info>,
+    #[account(mut, has_one = owner)]
+    pub badge: Account<'info, TrustBadge>;
+    /// Owner account used only for constraint verification
+    #[account(address = badge.owner)]
+    pub owner: SystemAccount<'info>;
+}
+
+#[derive(Accounts)]
+pub struct GetScore<'info> {
+    pub badge: Account<'info, TrustBadge>;
+}
+
+#[account]
+pub struct TrustBadge {
+    pub authority: Pubkey,
+    pub owner: Pubkey,
+    pub mint: Pubkey,
+    pub reputation_score: u64,
+    pub bump: u8,
+}
+
+impl TrustBadge {
+    pub const LEN: usize = 8 + // discriminator
+        32 + // authority
+        32 + // owner
+        32 + // mint
+        8 +  // reputation_score
+        1;   // bump
+}
+
+#[event]
+pub struct BadgeMinted {
+    pub owner: Pubkey,
+    pub mint: Pubkey,
+    pub reputation_score: u64,
+}
+
+#[event]
+pub struct ScoreUpdated {
+    pub owner: Pubkey,
+    pub mint: Pubkey,
+    pub reputation_score: u64,
+}
+
+#[event]
+pub struct ScoreQueried {
+    pub owner: Pubkey,
+    pub mint: Pubkey,
+    pub reputation_score: u64,
+}
+
+#[error_code]
+pub enum TrustBadgeError {
+    #[msg("Trust badge PDA missing bump seed")]
+    MissingBump,
+    #[msg("Caller is not authorized to update the reputation score")]
+    Unauthorized,
+    #[msg("Reputation score is out of range")]
+    ScoreOutOfRange,
+}

--- a/scripts/generate_pitch_deck.py
+++ b/scripts/generate_pitch_deck.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Generate a 3-slide pitch deck from a Markdown summary."""
+
+import argparse
+from pathlib import Path
+
+from docx import Document
+from pptx import Presentation
+from pptx.util import Inches, Pt
+
+DEFAULT_TITLES = ["Problem", "Solution", "Architecture"]
+
+
+def load_markdown_lines(markdown_path: Path) -> list[str]:
+    text = markdown_path.read_text(encoding='utf-8')
+    document = Document()
+    for line in text.splitlines():
+        document.add_paragraph(line.strip())
+    return [paragraph.text for paragraph in document.paragraphs if paragraph.text.strip()]
+
+
+def bucket_content(paragraphs: list[str]) -> dict[str, list[str]]:
+    sections: dict[str, list[str]] = {title: [] for title in DEFAULT_TITLES}
+    current = DEFAULT_TITLES[0]
+
+    for entry in paragraphs:
+        normalized = entry.strip()
+        if normalized.startswith('#'):
+            heading = normalized.lstrip('#').strip().title()
+            if heading in sections:
+                current = heading
+            continue
+
+        sections[current].append(normalized)
+
+    return sections
+
+
+def add_slide(prs: Presentation, title: str, bullets: list[str]) -> None:
+    layout = prs.slide_layouts[1]
+    slide = prs.slides.add_slide(layout)
+    slide.shapes.title.text = title
+    slide.shapes.title.text_frame.paragraphs[0].font.size = Pt(40)
+
+    body = slide.shapes.placeholders[1].text_frame
+    body.clear()
+
+    for bullet in bullets or ["Add supporting details here."]:
+        p = body.add_paragraph()
+        p.text = bullet
+        p.font.size = Pt(20)
+        p.level = 0
+
+
+def build_deck(markdown_path: Path, output_path: Path) -> None:
+    paragraphs = load_markdown_lines(markdown_path)
+    sections = bucket_content(paragraphs)
+
+    presentation = Presentation()
+    presentation.slide_width = Inches(13.33)
+    presentation.slide_height = Inches(7.5)
+
+    for title in DEFAULT_TITLES:
+        add_slide(presentation, title, sections.get(title, []))
+
+    presentation.save(output_path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Generate a pitch deck from Markdown content.')
+    parser.add_argument('markdown', type=Path, help='Path to the Markdown summary file')
+    parser.add_argument('--output', type=Path, default=Path('justthetip_pitch.pptx'), help='Output PowerPoint file')
+    args = parser.parse_args()
+
+    build_deck(args.markdown, args.output)
+    print(f"✅ Pitch deck created at {args.output}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/commands/tipCommand.js
+++ b/src/commands/tipCommand.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const { LAMPORTS_PER_SOL } = require('@solana/web3.js');
+const x402Client = require('../utils/x402Client');
+const trustBadgeService = require('../utils/trustBadge');
+const { createTipSuccessEmbed } = require('../utils/embedBuilders');
+const { isValidAmount } = require('../utils/validation');
+
+const MICROPAYMENT_SIGNER = process.env.X402_PAYER_SECRET;
+
+async function handleTipCommand(interaction, dependencies = {}) {
+  const payments = dependencies.x402Client || x402Client;
+  const badges = dependencies.trustBadgeService || trustBadgeService;
+  const db = dependencies.sqlite || require('../../db/db');
+
+  const recipient = interaction.options.getUser('user');
+  const amount = interaction.options.getNumber('amount');
+  const currency = interaction.options.getString('currency') || 'SOL';
+
+  if (!isValidAmount(amount)) {
+    await interaction.reply({ content: '❌ Amount must be a positive number.', ephemeral: true });
+    return;
+  }
+
+  if (recipient.id === interaction.user.id) {
+    await interaction.reply({ content: '😅 You cannot tip yourself. Try a friend instead!', ephemeral: true });
+    return;
+  }
+
+  if (currency.toUpperCase() !== 'SOL') {
+    await interaction.reply({ content: '⚠️ The x402 micropayment client currently supports SOL tips only.', ephemeral: true });
+    return;
+  }
+
+  if (!MICROPAYMENT_SIGNER) {
+    await interaction.reply({ content: '❌ Payment signer not configured. Set X402_PAYER_SECRET in your environment.', ephemeral: true });
+    return;
+  }
+
+  await interaction.deferReply();
+
+  try {
+    const senderBadge = await badges.requireBadge(interaction.user.id);
+    const recipientBadge = await badges.requireBadge(recipient.id);
+
+    const lamports = Math.round(amount * LAMPORTS_PER_SOL);
+    if (lamports <= 0) {
+      throw new Error('Calculated lamports must be greater than zero.');
+    }
+
+    const paymentResult = await payments.sendPayment({
+      fromSecret: MICROPAYMENT_SIGNER,
+      toAddress: recipientBadge.wallet_address,
+      amountLamports: lamports,
+      reference: `tip:${interaction.user.id}:${recipient.id}`,
+    });
+
+    db.getUser(interaction.user.id);
+    db.getUser(recipient.id);
+    db.recordTip(interaction.user.id, recipient.id, amount, currency, paymentResult.signature);
+
+    const senderScore = await badges.adjustReputation(interaction.user.id, 1);
+    const recipientScore = await badges.adjustReputation(recipient.id, 2);
+
+    const embed = createTipSuccessEmbed(interaction.user, recipient, amount, currency)
+      .setFooter({ text: `Sig: ${paymentResult.signature.slice(0, 8)}… | Sender Rep ${senderScore} | Receiver Rep ${recipientScore}` });
+
+    await interaction.editReply({ embeds: [embed] });
+  } catch (error) {
+    console.error('Tip command failed:', error);
+    await interaction.editReply({ content: `❌ Tip failed: ${error.message}` });
+  }
+}
+
+module.exports = {
+  handleTipCommand,
+};

--- a/src/components/TipHistory.jsx
+++ b/src/components/TipHistory.jsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react';
+
+const formatDate = (value) => {
+  const date = value ? new Date(value) : new Date();
+  return date.toLocaleString();
+};
+
+export default function TipHistory() {
+  const [tips, setTips] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadTips() {
+      try {
+        setLoading(true);
+        const response = await fetch('/api/tips');
+        if (!response.ok) {
+          throw new Error('Failed to load tip history');
+        }
+
+        const payload = await response.json();
+        if (!cancelled) {
+          setTips(payload.tips || []);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err.message);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadTips();
+
+    const interval = setInterval(loadTips, 15_000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  if (loading) {
+    return <div className="p-6 text-slate-300">Loading latest tips...</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="p-6 bg-rose-900/40 border border-rose-700 text-rose-100 rounded-lg">
+        Uh oh! {error}
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 bg-slate-900/60 border border-slate-700 rounded-xl shadow-lg">
+      <h2 className="text-xl font-semibold text-slate-100 mb-4">Recent Tips</h2>
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-slate-700">
+          <thead className="bg-slate-800/60">
+            <tr>
+              <th className="px-4 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider">Sender</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider">Receiver</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider">Amount</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider">Timestamp</th>
+            </tr>
+          </thead>
+          <tbody className="bg-slate-900/40 divide-y divide-slate-800">
+            {tips.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-4 py-6 text-center text-slate-400">
+                  No tips have been recorded yet. Be the first to send one! 🪙
+                </td>
+              </tr>
+            ) : (
+              tips.map((tip) => (
+                <tr key={`${tip.signature || tip.timestamp}-${tip.sender}-${tip.receiver}`} className="hover:bg-slate-800/40">
+                  <td className="px-4 py-3 text-slate-200">{tip.sender}</td>
+                  <td className="px-4 py-3 text-slate-200">{tip.receiver}</td>
+                  <td className="px-4 py-3 text-slate-100 font-semibold">{tip.amount} {tip.currency}</td>
+                  <td className="px-4 py-3 text-slate-400 text-sm">{formatDate(tip.timestamp)}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/utils/solanaDevTools.js
+++ b/src/utils/solanaDevTools.js
@@ -121,12 +121,12 @@ function initialize(options = {}) {
 }
 
 async function getProgramAccounts(programId, options = {}) {
-  const { cluster = DEFAULT_CLUSTER, rpcUrl, config } = options;
+  const { cluster = 'devnet', rpcUrl, config, log = true } = options;
   const connection = getConnection(cluster, rpcUrl);
   const programPublicKey = new PublicKey(programId);
   const accounts = await connection.getProgramAccounts(programPublicKey, config);
 
-  return accounts.map((account) => ({
+  const simplified = accounts.map((account) => ({
     pubkey: account.pubkey.toBase58(),
     lamports: account.account.lamports,
     owner: account.account.owner.toBase58(),
@@ -134,6 +134,15 @@ async function getProgramAccounts(programId, options = {}) {
     rentEpoch: account.account.rentEpoch,
     dataLength: account.account.data.length
   }));
+
+  if (log) {
+    logger.info(`[solana-dev-tools] Program ${programPublicKey.toBase58()} has ${simplified.length} accounts on ${cluster}`);
+    simplified.forEach((accountInfo, index) => {
+      logger.info(`  [${index + 1}] ${accountInfo.pubkey} — ${accountInfo.dataLength} bytes (${accountInfo.lamports} lamports)`);
+    });
+  }
+
+  return simplified;
 }
 
 async function requestAirdrop(walletAddress, lamports, options = {}) {

--- a/src/utils/trustBadge.js
+++ b/src/utils/trustBadge.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const { PublicKey } = require('@solana/web3.js');
+const logger = require('./logger');
+const solanaDevTools = require('./solanaDevTools');
+
+async function fetchBadge(discordId) {
+  if (!discordId) {
+    throw new Error('Missing Discord user id');
+  }
+
+  const sqlite = require('../../db/db');
+  const badge = sqlite.getTrustBadgeByDiscordId(discordId);
+  return badge || null;
+}
+
+async function confirmBadgeOnChain(walletAddress, mintAddress) {
+  if (!walletAddress || !mintAddress) {
+    return false;
+  }
+
+  try {
+    const connection = solanaDevTools.getConnection('devnet');
+    const owner = new PublicKey(walletAddress);
+    const mint = new PublicKey(mintAddress);
+    const accounts = await connection.getTokenAccountsByOwner(owner, { mint });
+    return accounts.value.length > 0;
+  } catch (error) {
+    logger.error(`[trust-badge] Failed to confirm badge on-chain: ${error.message}`);
+    return false;
+  }
+}
+
+async function requireBadge(discordId) {
+  const badge = await fetchBadge(discordId);
+  if (!badge) {
+    throw new Error('User is not verified with a TrustBadge NFT yet.');
+  }
+
+  const confirmed = await confirmBadgeOnChain(badge.wallet_address, badge.mint_address);
+  if (!confirmed) {
+    throw new Error('TrustBadge NFT could not be found on-chain. Ask the user to re-verify.');
+  }
+
+  return badge;
+}
+
+async function adjustReputation(discordId, delta) {
+  const sqlite = require('../../db/db');
+  sqlite.updateReputationScore(discordId, delta);
+  const score = sqlite.getReputationScore(discordId);
+  return score;
+}
+
+module.exports = {
+  fetchBadge,
+  requireBadge,
+  adjustReputation,
+  confirmBadgeOnChain,
+};

--- a/src/utils/x402Client.js
+++ b/src/utils/x402Client.js
@@ -1,0 +1,134 @@
+'use strict';
+
+const bs58 = require('bs58');
+const {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  clusterApiUrl,
+  LAMPORTS_PER_SOL,
+} = require('@solana/web3.js');
+const logger = require('./logger');
+
+const DEFAULT_CLUSTER = 'devnet';
+const COMMITMENT = 'confirmed';
+
+let cachedConnection = null;
+
+function getConnection() {
+  if (!cachedConnection) {
+    const endpoint = process.env.X402_RPC_URL || clusterApiUrl(DEFAULT_CLUSTER);
+    cachedConnection = new Connection(endpoint, COMMITMENT);
+    logger.info(`[x402] Connected to ${endpoint}`);
+  }
+
+  return cachedConnection;
+}
+
+function loadKeypair(secret) {
+  if (!secret) {
+    throw new Error('Missing secret key for x402 payment client');
+  }
+
+  try {
+    if (Array.isArray(secret)) {
+      return Keypair.fromSecretKey(Uint8Array.from(secret));
+    }
+
+    if (Buffer.isBuffer(secret)) {
+      return Keypair.fromSecretKey(Uint8Array.from(secret));
+    }
+
+    if (typeof secret === 'string') {
+      return Keypair.fromSecretKey(bs58.decode(secret.trim()));
+    }
+
+    throw new Error('Unsupported secret key format. Provide base58 string or byte array.');
+  } catch (error) {
+    throw new Error(`Failed to load signing key: ${error.message}`);
+  }
+}
+
+async function sendPayment({
+  fromSecret,
+  toAddress,
+  amountLamports,
+  reference,
+}) {
+  const connection = getConnection();
+  const payer = loadKeypair(fromSecret);
+
+  try {
+    const destination = new PublicKey(toAddress);
+    const transferInstruction = SystemProgram.transfer({
+      fromPubkey: payer.publicKey,
+      toPubkey: destination,
+      lamports: amountLamports,
+    });
+
+    const tx = new Transaction({
+      feePayer: payer.publicKey,
+      recentBlockhash: (await connection.getLatestBlockhash()).blockhash,
+    }).add(transferInstruction);
+
+    const signature = await connection.sendTransaction(tx, [payer], {
+      skipPreflight: false,
+      preflightCommitment: COMMITMENT,
+    });
+
+    logger.info(`[x402] Sent ${amountLamports} lamports from ${payer.publicKey} to ${destination} (ref: ${reference || 'n/a'})`);
+
+    await connection.confirmTransaction(signature, COMMITMENT);
+
+    return { signature, destination: destination.toBase58(), amountLamports };
+  } catch (error) {
+    logger.error(`[x402] Payment failed: ${error.message}`);
+    throw error;
+  }
+}
+
+async function getTransactionStatus(signature) {
+  const connection = getConnection();
+
+  try {
+    const status = await connection.getSignatureStatus(signature, { searchTransactionHistory: true });
+    const info = status.value;
+
+    if (!info) {
+      return { signature, status: 'unknown' };
+    }
+
+    if (info.err) {
+      return { signature, status: 'failed', error: info.err };
+    }
+
+    return {
+      signature,
+      status: info.confirmationStatus || 'confirmed',
+      slot: info.slot,
+    };
+  } catch (error) {
+    logger.error(`[x402] Failed to fetch transaction status for ${signature}: ${error.message}`);
+    throw error;
+  }
+}
+
+async function getBalance(publicKey) {
+  const connection = getConnection();
+  const address = new PublicKey(publicKey);
+  const lamports = await connection.getBalance(address);
+
+  return {
+    lamports,
+    sol: lamports / LAMPORTS_PER_SOL,
+  };
+}
+
+module.exports = {
+  sendPayment,
+  getTransactionStatus,
+  getBalance,
+  getConnection,
+};

--- a/tests/tipCommand.test.js
+++ b/tests/tipCommand.test.js
@@ -1,0 +1,60 @@
+describe('handleTipCommand', () => {
+  beforeEach(() => {
+    process.env.X402_PAYER_SECRET = '2'.repeat(88);
+    jest.resetModules();
+  });
+
+  it('transfers funds and updates reputation when both users are verified', async () => {
+    const { handleTipCommand } = require('../src/commands/tipCommand');
+    const sender = { id: 'sender', username: 'Alice' };
+    const recipient = { id: 'receiver', username: 'Bob', bot: false };
+
+    const interaction = {
+      user: sender,
+      options: {
+        getUser: jest.fn(() => recipient),
+        getNumber: jest.fn(() => 1.5),
+        getString: jest.fn(() => 'SOL'),
+      },
+      reply: jest.fn(),
+      deferReply: jest.fn(),
+      editReply: jest.fn(),
+    };
+
+    const x402Mock = {
+      sendPayment: jest.fn().mockResolvedValue({ signature: 'sig123' }),
+    };
+
+    const trustBadgeMock = {
+      requireBadge: jest
+        .fn()
+        .mockResolvedValueOnce({ wallet_address: 'wallet-sender', mint_address: 'mint-sender' })
+        .mockResolvedValueOnce({ wallet_address: 'wallet-receiver', mint_address: 'mint-receiver' }),
+      adjustReputation: jest.fn().mockResolvedValueOnce(5).mockResolvedValueOnce(8),
+    };
+
+    const sqliteMock = {
+      getUser: jest.fn(),
+      recordTip: jest.fn(),
+    };
+
+    await handleTipCommand(interaction, {
+      x402Client: x402Mock,
+      trustBadgeService: trustBadgeMock,
+      sqlite: sqliteMock,
+    });
+
+    expect(interaction.deferReply).toHaveBeenCalled();
+    expect(x402Mock.sendPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toAddress: 'wallet-receiver',
+        amountLamports: expect.any(Number),
+      }),
+    );
+    expect(trustBadgeMock.requireBadge).toHaveBeenCalledTimes(2);
+    expect(trustBadgeMock.adjustReputation).toHaveBeenNthCalledWith(1, 'sender', 1);
+    expect(trustBadgeMock.adjustReputation).toHaveBeenNthCalledWith(2, 'receiver', 2);
+    expect(sqliteMock.recordTip).toHaveBeenCalledWith('sender', 'receiver', 1.5, 'SOL', 'sig123');
+    expect(interaction.editReply).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add an x402 Solana micropayment client and TrustBadge helpers for NFT verification and reputation tracking
- update the Discord /tip command, Express API, and SQLite layer to enforce TrustBadge ownership, record tips, and expose history endpoints
- ship supporting artifacts including the TrustBadge Anchor instruction module, a React tip history table, Jest coverage, and a Markdown-to-PowerPoint generator script

## Testing
- npm test -- tipCommand.test.js

------
https://chatgpt.com/codex/tasks/task_e_690c22339134832f94d3828a639313b8